### PR TITLE
feat: #10 Implement filter-flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ struct Args {
         help = "Only filter directories containing this directory"
     )]
     contains_dir: String,
+
+    #[clap(short, long, default_value = "", help = "Filter following directories")]
+    filter: String,
     /*
     // Unimplemented options
         #[clap(short, long, help = "Be more verbose")]
@@ -34,9 +37,6 @@ struct Args {
             help = "Depth of recursion. Negative values are counted from bottom"
         )]
         depth: Option<i8>,
-
-        #[clap(short, long, default_value = "", help = "Filter following directories")]
-        filter: String,
 
         #[clap(short, long, default_value = "", help = "Ignore following directories")]
         ignore: String,
@@ -82,8 +82,11 @@ fn format_command(raw_command: &String) -> String {
 
 // Filter directory by name
 fn filter_dir(path_name: &PathBuf, args: &Args) -> bool {
-    if args.contains_dir.is_empty() || path_name.join(&args.contains_dir).exists() {
-        return true;
+    if !args.contains_dir.is_empty() && !path_name.join(&args.contains_dir).exists() {
+        return false;
     }
-    return false;
+    if !args.filter.is_empty() && !path_name.to_str().unwrap().contains(&args.filter) {
+        return false;
+    }
+    true
 }


### PR DESCRIPTION
This pull request includes modifications to the `Args` struct and the `filter_dir` function in the `src/main.rs` file to enhance directory filtering capabilities. The main changes involve reordering and refining the filter options.

Enhancements to directory filtering:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR26-R28): Added a new `filter` field to the `Args` struct to allow filtering directories by name.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL38-L40): Removed the previously unimplemented `filter` field from the `Args` struct to avoid redundancy.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL85-R92): Updated the `filter_dir` function to incorporate the new `filter` field, ensuring directories are filtered based on the specified criteria.