### PR TITLE
feat: #11 Implement ignore-flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ struct Args {
 
     #[clap(short, long, default_value = "", help = "Filter following directories")]
     filter: String,
+
+    #[clap(short, long, default_value = "", help = "Ignore following directories")]
+    ignore: String,
     /*
     // Unimplemented options
         #[clap(short, long, help = "Be more verbose")]
@@ -37,9 +40,6 @@ struct Args {
             help = "Depth of recursion. Negative values are counted from bottom"
         )]
         depth: Option<i8>,
-
-        #[clap(short, long, default_value = "", help = "Ignore following directories")]
-        ignore: String,
     */
 }
 
@@ -86,6 +86,9 @@ fn filter_dir(path_name: &PathBuf, args: &Args) -> bool {
         return false;
     }
     if !args.filter.is_empty() && !path_name.to_str().unwrap().contains(&args.filter) {
+        return false;
+    }
+    if !args.ignore.is_empty() && path_name.to_str().unwrap().contains(&args.ignore) {
         return false;
     }
     true


### PR DESCRIPTION
This pull request includes changes to the `src/main.rs` file to add a new command-line argument for ignoring directories and update the filtering logic accordingly. The most important changes include adding the new `ignore` argument to the `Args` struct and modifying the `filter_dir` function to incorporate this new argument.

### Command-line argument enhancements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29-R31): Added a new `ignore` argument to the `Args` struct to allow users to specify directories to ignore.

### Code logic updates:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL40-L42): Removed the previously commented-out `ignore` argument from the `Args` struct.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR91-R93): Updated the `filter_dir` function to check the new `ignore` argument and exclude directories that match the specified ignore pattern.